### PR TITLE
Use item.content_markdown instead of item.content

### DIFF
--- a/search.html
+++ b/search.html
@@ -26,7 +26,7 @@ permalink: /search/
 							"description": "{{item.description | xml_escape }}",
 		  				"type": "{{item.type | xml_escape}}",
 							"url": "{{ site.baseurl }}/#{{ item.id | replace: '/', '' | replace: '.', '' | xml_escape }}",
-							"content": {{ item.content | strip_html | replace_regex: "[\s/\n]+"," " | strip | jsonify }}
+							"content": {{ item.content_markdown | strip_html | replace_regex: "[\s/\n]+"," " | strip | jsonify }}
 						}
 						{% assign added = true %}
 					{% endunless %}


### PR DESCRIPTION
Search wasn't working, file contents weren't being indexed (content properties were empty), simple typo "item.content" needs to be "item.content_markdown". Fix gets file contents into index and I get expected search results in generated site. There may be further tweaks needed in filtering the content (for example, markdown table pipes and dashes should be filtered out), but this well enough for now.