### PR TITLE
Sidebar nav from search results broken when using baseurl

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -8,7 +8,7 @@
 					{% assign sorted_docs = collection.docs | sort: "position_number" %}
 					{% for doc in sorted_docs %}
 						<li>
-							<a href="{% if page.url != '/' %}/{% endif %}#{{ doc.id | replace: '/', '' | replace: '.', '' }}">
+							<a href="{% if page.url != '/' %}{{ site.baseurl }}/{% endif %}#{{ doc.id | replace: '/', '' | replace: '.', '' }}">
 								{{ doc.title }}
 								{% if doc.type %}<span class="endpoint {{ doc.type }}"></span>{% endif %}
 							</a>


### PR DESCRIPTION
The search/index.html results page as built assumes the root for the sidebar nav links. When you set a baseurl for your project, the sidebar nav links break. Added site.baseurl to link resolution.